### PR TITLE
add new macros to highlight text additions, deletions and changes

### DIFF
--- a/general_rules/Organization_of_the_Competition.tex
+++ b/general_rules/Organization_of_the_Competition.tex
@@ -7,7 +7,7 @@ The Technical Committee and the Organizational Committee will jointly determine 
 The number of people to register per team is not restricted by default, but may be limited due to local arrangements. Teams that plan to bring more than four members are advised to contact the Organizing Committee beforehand.
 During registration, each team has to designate one member as team leader. A change of the team leader must be communicated to the Organizing Committee. The team leader is the only person who can officially communicate with the referees during a run, e.g. to decide to abort a run, to call a restart, etc. The team leader can ask the OC to accept additional teams members for these tasks.
 \par
-During on-site registration and upon request by the Organizing Committee a team has to nominate one or more referees for the competition. If a team fails to provide referees in an appropriate way, the Organizing Committee \todo{old version: may take actions such as reduction of points for the respective team. /// new version: chooses an arbitrary member of the team for this position.}
+During on-site registration and upon request by the Organizing Committee a team has to nominate one or more referees for the competition. If a team fails to provide referees in an appropriate way, the Organizing Committee \revcha{may take actions such as reduction of points for the respective team.}{chooses an arbitrary member of the team for this position.}
 
 
 \subsection{Team Practice and Use of Arenas}

--- a/setup/macros.tex
+++ b/setup/macros.tex
@@ -38,6 +38,10 @@
 \newcommand{\TODO}[1]{\textbf{\it\color{red}{TODO:\\}#1\color{black}}}
 \newcommand{\chk}[1]{\textbf{\color{red}#1\color{black}}}
 
+\newcommand{\revadd}[1]{\textcolor{blue}{#1}}
+\newcommand{\revdel}[1]{\textcolor{red}{\sout{#1}}}
+\newcommand{\revcha}[2]{\revdel{#1}\revadd{#2}}
+
 \newcommand{\reworkon}{\marginpar{\raggedright\color{red}{$\downarrow$rework}\color{black}}}
 \newcommand{\reworkoff}{\marginpar{\raggedright\color{red}{$\uparrow$rework}\color{black}}}
 

--- a/setup/packages.tex
+++ b/setup/packages.tex
@@ -49,6 +49,8 @@
 \usepackage{titlesec}
 \usepackage{xfrac}
 
+\usepackage[normalem]{ulem}
+
 % Local Variables:
 % TeX-master: "../Rulebook"
 % End:


### PR DESCRIPTION
These are the highlighting macros which we used in the RoCKIn rulebook to illustrate if something has been added, needs to be deleted or should be changed. Especially, the last macro is/was very helpful. 
